### PR TITLE
Config vars ineffective when instantiating with attributes

### DIFF
--- a/Entities/Sentinel/User.php
+++ b/Entities/Sentinel/User.php
@@ -27,10 +27,10 @@ class User extends EloquentUser implements UserInterface
 
     public function __construct(array $attributes = [])
     {
-        parent::__construct($attributes);
-
         $this->loginNames = config('asgard.user.users.login-columns');
         $this->fillable = config('asgard.user.users.fillable');
+
+        parent::__construct($attributes);
     }
 
     /**


### PR DESCRIPTION
When instantiated with an array of attributes, User constructor will not take *fillable* and *login-columns* config settings into account - the *fill* method will be called  before the instance properties are overwritten with custom ones.