### PR TITLE
Fix dynamic relations. Add block to config file with example.

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -48,7 +48,17 @@ return [
         'first_name',
         'last_name',
     ],
-
+    /*
+     |--------------------------------------------------------------------------
+     | Dynamic relations
+     |--------------------------------------------------------------------------
+     | Add relations that will be dynamically added to the User entity
+     */
+    'relations' => [
+//        'extension' => function ($self) {
+//            return $self->belongsTo(UserExtension::class, 'user_id', 'id')->first();
+//        }
+    ],
     /*
     |--------------------------------------------------------------------------
     | Custom Sidebar Class

--- a/Entities/Sentinel/User.php
+++ b/Entities/Sentinel/User.php
@@ -94,10 +94,8 @@ class User extends EloquentUser implements UserInterface
 
     public function __call($method, $parameters)
     {
-        $class_name = class_basename($this);
-
         #i: Convert array to dot notation
-        $config = implode('.', ['relations', $class_name, $method]);
+        $config = implode('.', ['asgard.user.config.relations', $method]);
 
         #i: Relation method resolver
         if (config()->has($config)) {


### PR DESCRIPTION
Fixes the following exception:

```php
BadMethodCallException in Builder.php line 2380:
Call to undefined method Illuminate\Database\Query\Builder::userAddresses()
```