### PR TITLE
Failed Login Shows Passwords In The DOM

### DIFF
--- a/Resources/views/public/login.blade.php
+++ b/Resources/views/public/login.blade.php
@@ -22,7 +22,7 @@
             </div>
             <div class="form-group has-feedback {{ $errors->has('password') ? ' has-error' : '' }}">
                 <input type="password" class="form-control"
-                       name="password" placeholder="{{ trans('user::auth.password') }}" value="{{ old('password')}}">
+                       name="password" placeholder="{{ trans('user::auth.password') }}">
                 <span class="glyphicon glyphicon-lock form-control-feedback"></span>
                 {!! $errors->first('password', '<span class="help-block">:message</span>') !!}
             </div>


### PR DESCRIPTION
If for whatever reason you failed to login the password you sent will be written in plaintext in the returned DOM